### PR TITLE
Fix 'Practice later' button issue

### DIFF
--- a/src/widgets/funcs/checkNonCardSlide.ts
+++ b/src/widgets/funcs/checkNonCardSlide.ts
@@ -2,5 +2,6 @@ import { QueueItemType } from '@remnote/plugin-sdk';
 
 export function checkNonCardSlide(input: number | QueueItemType): boolean {
 	const cardSlides = new Set([1, 2, 3, 5]);
-	return !cardSlides.has(input);
+	const practiceLaterPage = 'PracticeLater';
+	return !cardSlides.has(input) && input !== practiceLaterPage;
 }

--- a/src/widgets/gamePadQueueHandler.tsx
+++ b/src/widgets/gamePadQueueHandler.tsx
@@ -27,6 +27,7 @@ function GamepadInput() {
 	);
 	const [isLookback, setIsLookback] = useState(false);
 	const [isNonCardSlide, setIsCardSlide] = useState(false);
+	const [isPracticeLaterPage, setIsPracticeLaterPage] = useState(false);
 	const getSessionStatus = async () => {
 		return await plugin.storage.getSession('settingsUiShown');
 	};
@@ -57,6 +58,7 @@ function GamepadInput() {
 			return;
 		}
 		setIsCardSlide(checkNonCardSlide(cardSlide!));
+		setIsPracticeLaterPage(cardSlide === 'PracticeLater');
 	};
 
 	const fetchLookback = async () => {
@@ -111,12 +113,12 @@ function GamepadInput() {
 			}
 		});
 		const showAnswer = async () => {
-			if (buttonReleased && !(await hasRevealedAnswer()) && !isLookback && !isNonCardSlide) {
+			if (buttonReleased && !(await hasRevealedAnswer()) && !isLookback && !isNonCardSlide && !isPracticeLaterPage) {
 				plugin.queue.showAnswer();
 			}
 		};
 		showAnswer();
-	}, [buttonReleased, isLookback, isNonCardSlide]);
+	}, [buttonReleased, isLookback, isNonCardSlide, isPracticeLaterPage]);
 
 	// Rate current card
 	useEffect(() => {
@@ -130,7 +132,7 @@ function GamepadInput() {
 			return;
 		}
 		const rateCard = async () => {
-			if (buttonReleased && ((await hasRevealedAnswer()) || isNonCardSlide)) {
+			if (buttonReleased && ((await hasRevealedAnswer()) || isNonCardSlide || isPracticeLaterPage)) {
 				logMessage(
 					plugin,
 					LogType.Info,
@@ -142,7 +144,7 @@ function GamepadInput() {
 		};
 		plugin.messaging.broadcast({ changeButtonCSS: null });
 		rateCard();
-	}, [buttonReleased, isNonCardSlide]);
+	}, [buttonReleased, isNonCardSlide, isPracticeLaterPage]);
 	return <div></div>;
 }
 


### PR DESCRIPTION
Fixes #6

Add logic to handle the 'Practice later' page specifically and ensure the 'B' button works correctly without requiring an additional click.

* **src/widgets/gamePadQueueHandler.tsx**
  - Add `isPracticeLaterPage` state to track if the current slide is the 'Practice later' page.
  - Update `fetchCardSlide` function to set `isPracticeLaterPage` when the slide is 'PracticeLater'.
  - Modify `showAnswer` and `rateCard` functions to include checks for `isPracticeLaterPage`.

* **src/widgets/funcs/checkNonCardSlide.ts**
  - Update `checkNonCardSlide` function to include a check for the 'Practice later' page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/remnoteio/remnote-gamepad/pull/7?shareId=1fce8eff-de58-4a0a-a9be-e19754f59b04).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced slide navigation so that the dedicated “Practice Later” page is now treated differently.
	- Improved gamepad control logic to prevent regular card actions when interacting with the “Practice Later” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- [ ] Tested